### PR TITLE
Allow for no mutation type in schema

### DIFF
--- a/addon/mocks/create.js
+++ b/addon/mocks/create.js
@@ -9,9 +9,13 @@ export const composeCreateMocksForSchema =
   (createMocks, mockQuery, mockMutation) =>
     (schema, db, options) => {
       let typesAndMockFns = [
-        [schema._queryType, mockQuery],
-        [schema._mutationType, mockMutation]
+        [schema._queryType, mockQuery]
       ];
+
+      if (schema._mutationType) {
+        typesAndMockFns.push([schema._mutationType, mockMutation]);
+      }
+
       let mocks = createMocks(typesAndMockFns, db, options);
 
       return mocks;

--- a/tests/unit/mocks/create-test.js
+++ b/tests/unit/mocks/create-test.js
@@ -23,6 +23,21 @@ module('Unit | Mocks | create', function() {
 
       createMocksForSchema(schema, db, options);
     });
+
+    test('it creates mocks for query type, if no mutation type', function(assert) {
+      assert.expect(1);
+
+      let schema = { _queryType: {} };
+      let createMocks = (typesAndMockFns) => {
+        assert.deepEqual(typesAndMockFns, [
+          [schema._queryType, null]
+        ], 'It received the query and mutation types to mock');
+      };
+      let createMocksForSchema =
+        composeCreateMocksForSchema(createMocks, null, null);
+
+      createMocksForSchema(schema);
+    });
   });
 
   module('reduce mocks', function() {

--- a/tests/unit/mocks/create-test.js
+++ b/tests/unit/mocks/create-test.js
@@ -31,7 +31,7 @@ module('Unit | Mocks | create', function() {
       let createMocks = (typesAndMockFns) => {
         assert.deepEqual(typesAndMockFns, [
           [schema._queryType, null]
-        ], 'It received the query and mutation types to mock');
+        ], 'It received the query type to mock');
       };
       let createMocksForSchema =
         composeCreateMocksForSchema(createMocks, null, null);


### PR DESCRIPTION
Fixes #16.
This PR makes mutation types in the schema optional.