### PR TITLE
Unwrap non-null types

### DIFF
--- a/addon/fields/selections/index.js
+++ b/addon/fields/selections/index.js
@@ -1,10 +1,20 @@
 import createFieldInfo from '../info/create';
 import { getFieldNameAndAlias } from '../name';
 import { fragmentFieldsReducer, inlineFragmentFieldsReducer } from './fragments';
-import { partial } from '../../utils';
+import { partial, unwrapNonNull } from '../../utils';
 
-const getFieldType = (type, fieldName) =>
-  fieldName !== '__typename' && type._fields[fieldName].type;
+const getFieldType = (type, fieldName) => {
+  if (fieldName === '__typename') {
+    return null;
+  }
+
+  type = unwrapNonNull(type);
+
+  let field = type._fields[fieldName];
+  let fieldType = unwrapNonNull(field.type);
+
+  return fieldType;
+}
 
 export const selectedFieldsReducer =
   (getFieldNameAndAlias, getFieldType, createFieldInfo, getType, type, fragments, selections, selection) => {

--- a/addon/mocks/mutation.js
+++ b/addon/mocks/mutation.js
@@ -1,4 +1,4 @@
-import { contextSet, isFunction, reduceKeys } from '../utils';
+import { contextSet, isFunction, reduceKeys, unwrapNonNull } from '../utils';
 import { getRecords } from '../db';
 import { resolveVarName } from '../filter/vars';
 
@@ -11,6 +11,8 @@ const mapVars = composeMapVars(resolveVarName);
 
 export const composeMockMutation = (getRecords, mapVars) =>
   (db, options = {}, _, vars, __, { fieldName, returnType }) => {
+    returnType = unwrapNonNull(returnType);
+
     let { mutations = {}, varsMap = {} } = options;
     let mutation = mutations[fieldName];
     let records = getRecords(db, returnType.name);

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -1,3 +1,5 @@
+import { GraphQLNonNull } from 'graphql';
+
 const sortEdgesKeysBeforePageInfo = (list) => list.sort();
 
 export function contextPush(context, k, v) {
@@ -35,3 +37,5 @@ export const composeReduceKeys = (sortKeys) =>
     sortKeys(Object.keys(obj)).reduce(reducerFn, defaultValue);
 
 export const reduceKeys = composeReduceKeys(sortEdgesKeysBeforePageInfo);
+
+export const unwrapNonNull = (type) => type instanceof GraphQLNonNull ? type.ofType : type;

--- a/tests/dummy/app/gql/schema.graphql
+++ b/tests/dummy/app/gql/schema.graphql
@@ -19,7 +19,7 @@ type LineItem {
 }
 
 type LineItemConnection {
-  edges: [LineItemEdge]
+  edges: [LineItemEdge!]!
   pageInfo: PageInfo!
 }
 

--- a/tests/dummy/app/gql/schema.graphql
+++ b/tests/dummy/app/gql/schema.graphql
@@ -29,7 +29,7 @@ type LineItemEdge {
 }
 
 type Mutation {
-  updatePerson(id: ID!, personAttributes: PersonAttributes!): Person
+  updatePerson(id: ID!, personAttributes: PersonAttributes!): Person!
 }
 
 interface Node {


### PR DESCRIPTION
We ran into the following error due to having non-null `edges` fields in our schema:

```graphql
type FooConnection {
  edges: [FooNode!]!
  #              ↑ ↑
}
```

```
Cannot read property 'cursor' of undefined
```

And a similar issue with non-null mutation return types:

```graphql
mutation {
  createFoo(input: CreateFooInput!): CreateFooResult!
  #                                                 ↑
}
```

```
Cannot read property 'replace' of undefined
```

---

This PR adds examples of non-null `edges` and non-null mutation return types to the schema and the accompanying logic to unwrap non-null types as required.

We deliberately modified only one of the two occurrences of `edges` to ensure it continues to work both ways.

We’ve been slightly lazy an amended the single existing mutation rather than adding a second mutation to test against. Happy to add an explicit mutation example if needsbe.