### PR TITLE
Unwrap non-null types when computing table name

### DIFF
--- a/addon/fields/records.js
+++ b/addon/fields/records.js
@@ -1,11 +1,12 @@
 import { getNodeField } from '../relay/node';
 import { getTableNameForField } from '../db';
+import { unwrapNonNull } from '../utils';
 
 export const composeGetRecordsByFieldName = (getNodeField, getTableNameForField) =>
   (fieldName, field, db, options = {}) => {
     let { fieldsMap = {} } = options;
     let nodeField = getNodeField(fieldName, field);
-    let typeName = (nodeField || field).type.name;
+    let typeName = unwrapNonNull((nodeField || field).type).name;
     let tableName = getTableNameForField(fieldName, field.parent, typeName, fieldsMap);
     let table = db[tableName] || [{}];
 


### PR DESCRIPTION
This allows for fields like this:

```graphql
type Thing {
  metadata: [Pair!]!
}

type Pair {
  key: String!
  value: String!
}
```