### PR TITLE
Allow createGraphQLHandler() to be used without options

### DIFF
--- a/addon/handler.js
+++ b/addon/handler.js
@@ -13,7 +13,7 @@ export const composeCreateGraphQLHandler =
         let { query, variables } = parseRequest(request.requestBody);
         let schema = createSchema(rawSchema);
 
-        if (options.varsMap) {
+        if (options && options.varsMap) {
           deprecate('ember-cli-mirage-graphql varsMap is deprecated, please use argsMap instead', false, {
             id: 'ember-cli-mirage-graphql.vars-map',
             until: '1.0.0',


### PR DESCRIPTION
This bug was caused when this deprecation for `varsMap` was added.

This fixes #27 for me.