### PR TITLE
Unwrap type for non-null lists of non null items

### DIFF
--- a/addon/fields/info/create.js
+++ b/addon/fields/info/create.js
@@ -2,6 +2,7 @@ import FieldInfo from './model';
 import { getArgsForField } from '../args';
 import { getIsRelayConnection } from '../../relay/connection';
 import { getSelectedFields } from '../selections';
+import { unwrapNonNull } from '../../utils';
 
 const composeGetFieldInfo = (getArgsForField, getSelectedFields, getIsRelayConnection) =>
   (field, type, fragments, getType) => {
@@ -19,6 +20,7 @@ const getFieldInfo = composeGetFieldInfo(getArgsForField, getSelectedFields,
 
 export const composeCreateFieldInfo = (getFieldInfo) =>
   (field, fieldName, type, fragments, getType) => {
+    type = unwrapNonNull(type);
     let { args, fields, isList, isRelayConnection, recordType } =
       getFieldInfo(field, type, fragments, getType);
 

--- a/tests/acceptance/non-null-list-of-people-test.js
+++ b/tests/acceptance/non-null-list-of-people-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@ember/test-helpers';
+
+module('Acceptance | non null list of people', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('it correctly unwraps non null list of non null items', async function(assert) {
+    server.createList('person', 2);
+
+    await visit('/people/non-null-list-of-people');
+
+    let people = this.element.querySelectorAll('h2');
+
+    assert.equal(people.length, 2, 'There are 2 people displayed');
+  });
+});

--- a/tests/dummy/app/gql/queries/non-null-list-of-people.graphql
+++ b/tests/dummy/app/gql/queries/non-null-list-of-people.graphql
@@ -1,0 +1,7 @@
+query nonNullListOfPeople {
+  nonNullListOfPeople {
+    id
+    firstName
+    lastName
+  }
+}

--- a/tests/dummy/app/gql/schema.graphql
+++ b/tests/dummy/app/gql/schema.graphql
@@ -99,4 +99,6 @@ type Query {
   people(firstName: String, lastName: String, pageSize: Int): [Person]
 
   peopleSameAgeAsDogYears: [Person]
+
+  nonNullListOfPeople: [Person!]!
 }

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,6 +9,7 @@ const Router = EmberRouter.extend({
 Router.map(function() {
   this.route('customer', { path: '/customer/:customer_id' });
   this.route('people', function() {
+    this.route('non-null-list-of-people');
     this.route('same-age-as-dog-years');
     this.route('same-name-as-pets');
   });

--- a/tests/dummy/app/routes/people/non-null-list-of-people.js
+++ b/tests/dummy/app/routes/people/non-null-list-of-people.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+import query from 'dummy/gql/queries/non-null-list-of-people';
+import { inject as service } from '@ember/service';
+
+export default Route.extend({
+  apollo: service(),
+
+  async model() {
+    let model = await this.get('apollo').watchQuery({ query });
+
+    return model;
+  }
+});

--- a/tests/dummy/app/templates/people/non-null-list-of-people.hbs
+++ b/tests/dummy/app/templates/people/non-null-list-of-people.hbs
@@ -1,0 +1,3 @@
+{{#each this.model.nonNullListOfPeople as |person|}}
+  <h2>{{person.firstName}} {{person.lastName}}</h2>
+{{/each}}


### PR DESCRIPTION
Non null lists were not unwrapped, producing an error like:

```
index.js:89 TypeError: Cannot read property 'id' of undefined
    at getFieldType (index.js:15)
    at selectedFieldsReducer (index.js:26)
    at utils.js:41
    at Array.reduce (<anonymous>)
    at index.js:41
    at create.js:15
    at create.js:35
    at query.js:29
    at Object.nonNullListOfPeople (utils.js:41)
    at eval (mock.js:105)
```
Added an acceptance test covering the problem to prevent regressions.

This fixes #29 