### PR TITLE
feat: custom scalar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ You may pass in options when creating a request handler. The options take the fo
     Person: { // arguments are mapped on a per-type basis
       pageSize: (records, _, pageSize) => records.slice(0, pageSize)
     }
+  },
+  /*
+  `scalarMocks` is used if you have custom scalars and you need to mock them to
+   return a default value
+  */
+  scalarMocks: {
+    MyCustomScalar: () => {
+      return 'some custom value'
+    }
   }
 }
 ```

--- a/addon/mocks/create.js
+++ b/addon/mocks/create.js
@@ -18,6 +18,10 @@ export const composeCreateMocksForSchema =
 
       let mocks = createMocks(typesAndMockFns, db, options);
 
+      if (options && options.scalarMocks) {
+        mocks = Object.assign({}, mocks, options.scalarMocks)
+      }
+
       return mocks;
     };
 

--- a/tests/acceptance/person-test.js
+++ b/tests/acceptance/person-test.js
@@ -15,12 +15,14 @@ module('Acceptance | person', function(hooks) {
     let city = element.querySelector('.person-address-city').textContent;
     let state = element.querySelector('.person-address-state').textContent;
     let zip = element.querySelector('.person-address-zip').textContent;
+    let createdAt = element.querySelector('.person-created-at').textContent;
 
     assert.equal(line1, address.line1, 'It displays address line 1');
     assert.equal(line2, address.line2, 'It displays address line 2');
     assert.equal(city, address.city, 'It displays address city');
     assert.equal(state, address.state, 'It displays address state');
     assert.equal(zip, address.zip, 'It displays address zip');
+    assert.equal(createdAt, person.createdAt, 'It displays person created at');
   }
 
   test('it can display belongsTo related data 1', async function(assert) {

--- a/tests/dummy/app/gql/queries/person.graphql
+++ b/tests/dummy/app/gql/queries/person.graphql
@@ -16,5 +16,6 @@ query($id: ID!) {
       name
       weight
     }
+    createdAt
   }
 }

--- a/tests/dummy/app/gql/schema.graphql
+++ b/tests/dummy/app/gql/schema.graphql
@@ -1,3 +1,5 @@
+scalar Date
+
 type Address {
   id: ID!
   line1: String!
@@ -81,6 +83,7 @@ type Person {
   firstName: String!
   lastName: String!
   pets(name: String): [Pet]
+  createdAt: Date!
 }
 
 input PersonAttributes {

--- a/tests/dummy/app/templates/person/index.hbs
+++ b/tests/dummy/app/templates/person/index.hbs
@@ -12,6 +12,7 @@
     <span class="person-address-state">{{model.human.address.state}}</span>
     <span class="person-address-zip">{{model.human.address.zip}}</span>
   </div>
+  <div class="person-created-at">{{model.human.createdAt}}</div>
   {{#if model.human.pets}}
     <table class="person-pets">
       <thead>

--- a/tests/dummy/mirage/factories/person.js
+++ b/tests/dummy/mirage/factories/person.js
@@ -5,5 +5,6 @@ const { list, name } = faker;
 export default Factory.extend({
   age: (i) => list.random(1, 10, 20, 30, 40, 50, 60, 70, 80, 90)(i),
   firstName: name.firstName,
-  surname: name.lastName
+  surname: name.lastName,
+  createdAt: '2019-01-01'
 });

--- a/tests/dummy/mirage/handlers/graphql.js
+++ b/tests/dummy/mirage/handlers/graphql.js
@@ -39,6 +39,11 @@ const OPTIONS = {
       pageSize: (people, variableName, pageSize) => people.slice(0, pageSize),
       lastName: 'surname'
     }
+  },
+  scalarMocks: {
+    Date: () => {
+      return '2019-01-01'
+    }
   }
 };
 

--- a/tests/unit/mocks/scalars-test.js
+++ b/tests/unit/mocks/scalars-test.js
@@ -1,0 +1,23 @@
+import createMocksForSchema from
+  'ember-cli-mirage-graphql/mocks/create';
+import { module, test } from 'qunit';
+
+module('Unit | Mocks | scalars', function() {
+  module('mock', function() {
+
+    test('creates scalars from options', function(assert) {
+      let schema = { _mutationType: {}, _queryType: {} };
+      let db = {};
+      let fieldName = 'foo';
+      let value = 'custom value'
+      let scalarMock = () => value;
+      let options = {
+        scalarMocks: { [fieldName]: scalarMock }
+      };
+      const mocks = createMocksForSchema(schema, db, options);
+
+      assert.equal(typeof mocks[fieldName], 'function', 'mock scalar set on mocks');
+      assert.equal(mocks[fieldName](), value, 'custom scalar returns proper value');
+    });
+  });
+});


### PR DESCRIPTION
Currently there is no ability to add support for custom scalars for example `Map`. This gives the ability to add mocks for your custom scalars. an example setup would be in your options object to do the following.

```javascript
options = {
  scalarMocks: {
    Map: () => {
      return { foo: 'bar' }
    }
  }
}
```
Then anytime a custom scalar of Map is called, it resolves using the specified resolver.