### PR TITLE
Update dummy app person example

### DIFF
--- a/tests/acceptance/person/edit-test.js
+++ b/tests/acceptance/person/edit-test.js
@@ -17,9 +17,9 @@ module('Acceptance | edit person', function(hooks) {
 
     await fillIn(lastNameInput, newLastName);
     await click('.person-save');
-    await visit('/people');
+    await visit(`/person/${person.id}`);
 
-    let lastName = this.element.querySelector('.people-last-name');
+    let lastName = this.element.querySelector('.person-last-name');
 
     assert.equal(lastName.textContent, newLastName, 'The last name changed');
   });

--- a/tests/acceptance/person/edit-test.js
+++ b/tests/acceptance/person/edit-test.js
@@ -17,7 +17,6 @@ module('Acceptance | edit person', function(hooks) {
 
     await fillIn(lastNameInput, newLastName);
     await click('.person-save');
-    await visit(`/person/${person.id}`);
 
     let lastName = this.element.querySelector('.person-last-name');
 

--- a/tests/dummy/app/controllers/person/edit.js
+++ b/tests/dummy/app/controllers/person/edit.js
@@ -16,16 +16,18 @@ export default Controller.extend({
   lastName: oneWay('model.human.lastName'),
 
   actions: {
-    savePerson(id, e) {
+    async savePerson(id, e) {
       e.preventDefault();
 
-      this.get('apollo').mutate({
+      let { updatePerson } = await this.get('apollo').mutate({
         mutation,
         variables: {
           id,
           personAttributes: getAttrsFromForm(e.target)
         }
       });
+
+      this.transitionToRoute('person', updatePerson.id);
     }
   }
 });

--- a/tests/dummy/app/gql/mutations/update-person.graphql
+++ b/tests/dummy/app/gql/mutations/update-person.graphql
@@ -1,5 +1,6 @@
 mutation UpdatePerson($id: ID!, $personAttributes: PersonAttributes!) {
   updatePerson(id: $id, personAttributes: $personAttributes) {
+    id
     firstName
     lastName
     age

--- a/tests/dummy/app/templates/person/index.hbs
+++ b/tests/dummy/app/templates/person/index.hbs
@@ -1,6 +1,7 @@
 <main class="person">
   <div class="person-full-name">
-    {{model.human.firstName}} {{model.human.lastName}}
+    <span class="person-first-name">{{model.human.firstName}}</span>
+    <span class="person-last-name">{{model.human.lastName}}</span>
   </div>
   <div class="person-age">
     {{model.human.age}}
@@ -13,6 +14,7 @@
     <span class="person-address-zip">{{model.human.address.zip}}</span>
   </div>
   <div class="person-created-at">{{model.human.createdAt}}</div>
+  {{link-to "Edit" "person.edit" model}}
   {{#if model.human.pets}}
     <table class="person-pets">
       <thead>

--- a/tests/dummy/mirage/handlers/graphql.js
+++ b/tests/dummy/mirage/handlers/graphql.js
@@ -2,7 +2,11 @@ import createGraphQLHandler from 'ember-cli-mirage-graphql/handler';
 import schema from 'dummy/gql/schema';
 import { contextSet, reduceKeys } from 'ember-cli-mirage-graphql/utils';
 
-const adaptPersonAttrs = (attrs) =>
+const adaptPersonAttrsFrom = (attrs) =>
+  reduceKeys(attrs, (_attrs, key) =>
+    contextSet(_attrs, key === 'surname' ? 'lastName' : key, attrs[key]), {});
+
+const adaptPersonAttrsTo = (attrs) =>
   reduceKeys(attrs, (_attrs, key) =>
     contextSet(_attrs, key === 'lastName' ? 'surname' : key, attrs[key]), {});
 
@@ -32,7 +36,9 @@ const OPTIONS = {
   },
   mutations: {
     updatePerson: (people, { id, personAttributes }) =>
-      people.update(id, adaptPersonAttrs(personAttributes))
+      adaptPersonAttrsFrom(
+        people.update(id, adaptPersonAttrsTo(personAttributes))
+      )
   },
   argsMap: {
     Person: {


### PR DESCRIPTION
This update to the dummy app fixes an issue where mapped fields for a `Person` type were correctly mapped for queries and only partially correctly mapped for mutations.

Fixes #36.

This adds an edit link to the person index page and changes the person edit page form submission so successful saves result in a redirect to the person index page.