### PR TITLE
Fix using the addon as a runtime dependency of another addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,9 @@ module.exports = {
     }
   },
   included(app) {
-    let config = this.app.project.config(app.env);
+    let config = app.project.config();
 
-    this.appEnv = app.env;
+    this.appEnv = config.environment;
     this.mirageConfig = config['ember-cli-mirage'] || {};
 
     this._super.included.apply(this, arguments);


### PR DESCRIPTION
When including this addon as a runtime dependency of another addon, I encountered the following error: `Cannot read property 'project' of undefined`.

The error occurs at this line: https://github.com/kloeckner-i/ember-cli-mirage-graphql/blob/master/index.js#L25

I have set up a reproduction here: https://github.com/bertdeblock/ember-cli-mirage-graphql-repro
The error should occur if you run `ember s` (so running the dummy app).

This PR should fix this error. 🤞

Let me know if you want me to change anything.