### PR TITLE
handle mutation that returns an array

### DIFF
--- a/addon/mocks/mutation.js
+++ b/addon/mocks/mutation.js
@@ -1,4 +1,5 @@
 import { contextSet, isFunction, reduceKeys, unwrapNonNull } from '../utils';
+import { GraphQLList } from 'graphql';
 import { getRecords } from '../db';
 import { resolveArgName } from '../fields/args';
 
@@ -12,6 +13,10 @@ const mapArgs = composeMapArgs(resolveArgName);
 export const composeMockMutation = (getRecords, mapArgs) =>
   (db, options = {}, _, args, __, { fieldName, returnType }) => {
     returnType = unwrapNonNull(returnType);
+
+    if (returnType instanceof GraphQLList) {
+      returnType = returnType.ofType
+    }
 
     let { mutations = {}, argsMap = {} } = options;
     let mutation = mutations[fieldName];

--- a/tests/acceptance/new-person-test.js
+++ b/tests/acceptance/new-person-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { click, fillIn, visit } from '@ember/test-helpers';
+
+module('Acceptance | new person', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('it can create a person via mutation and handles an array response', async function(assert) {
+    let newFirstName = 'Dave';
+    let newLastName = 'Jones';
+    let newAge = 44;
+
+    assert.ok(this.server.db.people.length === 0)
+
+    await visit(`/person-new`);
+
+
+    let firstNameInput = this.element.querySelector('#person-first-name');
+    let lastNameInput = this.element.querySelector('#person-last-name');
+    let ageInput = this.element.querySelector('#person-age');
+
+    await fillIn(firstNameInput, newFirstName);
+    await fillIn(lastNameInput, newLastName);
+    await fillIn(ageInput, newAge);
+    await click('.person-save');
+
+    let lastName = this.element.querySelector('.person-last-name');
+
+    assert.equal(lastName.textContent, newLastName, 'a person with with the correct last name was created');
+    assert.ok(this.server.db.people.length === 1, 'a new person was persisted to the DB')
+  });
+})

--- a/tests/dummy/app/controllers/person-new.js
+++ b/tests/dummy/app/controllers/person-new.js
@@ -1,0 +1,36 @@
+import Controller from '@ember/controller';
+import mutation from 'dummy/gql/mutations/create-person';
+import { contextSet } from 'ember-cli-mirage-graphql/utils';
+import { inject as service } from '@ember/service';
+
+function getAttrsFromForm(form) {
+  let inputNodes = [ ...form.querySelectorAll('input') ];
+
+  return inputNodes.reduce((attrs, { name, value }) =>
+    contextSet(attrs, name, value), {});
+}
+
+export default Controller.extend({
+  apollo: service(),
+  lastName: '',
+  firstName: '',
+  age: null,
+
+  actions: {
+    async savePerson(e) {
+      e.preventDefault();
+
+      let attrs = getAttrsFromForm(e.target)
+      attrs.age = Number(attrs.age)
+
+      let { createPerson } = await this.get('apollo').mutate({
+        mutation,
+        variables: {
+          personAttributes: attrs
+        }
+      });
+
+      this.transitionToRoute('person', createPerson[0].id);
+    }
+  }
+});

--- a/tests/dummy/app/gql/mutations/create-person.graphql
+++ b/tests/dummy/app/gql/mutations/create-person.graphql
@@ -1,0 +1,8 @@
+mutation CreatePerson($personAttributes: PersonAttributes!) {
+  createPerson(personAttributes: $personAttributes) {
+    id
+    firstName
+    lastName
+    age
+  }
+}

--- a/tests/dummy/app/gql/schema.graphql
+++ b/tests/dummy/app/gql/schema.graphql
@@ -32,6 +32,8 @@ type LineItemEdge {
 
 type Mutation {
   updatePerson(id: ID!, personAttributes: PersonAttributes!): Person!
+
+  createPerson(personAttributes: PersonAttributes!): [Person]
 }
 
 interface Node {

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -16,6 +16,7 @@ Router.map(function() {
   this.route('person', { path: '/person/:person_id' }, function() {
     this.route('edit');
   });
+  this.route('person-new');
   this.route('pets-and-people');
 });
 

--- a/tests/dummy/app/templates/person-new.hbs
+++ b/tests/dummy/app/templates/person-new.hbs
@@ -1,0 +1,24 @@
+<form onsubmit={{action "savePerson"}}>
+  <div>
+    <label for="person-first-name">First Name:</label>
+    {{input id="person-first-name"
+            name="firstName"
+            value=firstName
+            class="person-last-name"}}
+  </div>
+  <div>
+    <label for="person-last-name">Last Name:</label>
+    {{input id="person-last-name"
+            name="lastName"
+            value=lastName
+            class="person-last-name"}}
+  </div>
+  <div>
+    <label for="person-age">Age:</label>
+    {{input id="person-age"
+            name="age"
+            value=age
+            class="person-last-name"}}
+  </div>
+  <button type="submit" class="person-save">Save</button>
+</form>

--- a/tests/dummy/mirage/handlers/graphql.js
+++ b/tests/dummy/mirage/handlers/graphql.js
@@ -44,7 +44,9 @@ const OPTIONS = {
     updatePerson: (people, { id, personAttributes }) =>
       adaptPersonAttrsFrom(
         people.update(id, adaptPersonAttrsTo(personAttributes))
-      )
+      ),
+    createPerson: (people, { personAttributes }) => [people.insert(adaptPersonAttrsTo(personAttributes))]
+
   },
   argsMap: {
     Person: {


### PR DESCRIPTION
Hey 👋 
so, first laid eyes on graphql AND this codebase for the first time last week, so bear that in mind :) 
I feel like I'm likely just doing something wrong or have missed some config, however...

Issue: 
we have a mutation that returns a list of records
in the schema it looks something like this:
`createNewThing(input: CustomInput!): [NewThingRecord]`

```
input CustomInput {
  newThingTypeId: ID!
  newThingCount: Int!
}
```

and in our handler we have something along these lines:
```
  options.mutations.createNewThing = (newThings, { input }, _db) => {

    return [newThings.insert(_db.newThingTypesList.find(input.newThingTypeId))]
  }
```

the problem is that `newThings` that is passed to the mutation function is `undefined` here because the returnType `name` is nested under `ofType` instead of being top level in  `/mocks.mutations`

the work around we currently have is to just use the `_db` instance that's also passed but I'm wondering if we're just doing something else wrong. 
Maybe it's not common practice to return a list from a mutation?
or maybe I'm just missing some other configuration?

anyway... would love any eyes/input on this. 
I struggled a bit to follow the code that gets the `returnType`, I wonder if maybe some checking could be done earlier in the chain? if I'm not just doing something else dumb that is ;) 
