### PR TITLE
Allow GraphQLSchema instances to be passed to handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ import schema from 'app-name/path-to-your-schema';
 export default createGraphQLHandler(schema, /* options = {} */);
 ```
 
-Note: We use a simple command line tool to download our schema: [get-graphql-schema](https://www.npmjs.com/package/get-graphql-schema).
+Notes:
+* We use a simple command line tool to download our schema: [get-graphql-schema](https://www.npmjs.com/package/get-graphql-schema).
+* You can import and pass in your raw schema directly, as shown above, or you can pass in an instance of a `GraphQLSchema`, e.g., a case where you might merge multiple schemas.
 
 ---
 

--- a/addon/handler.js
+++ b/addon/handler.js
@@ -4,14 +4,17 @@ import {
   createSchema
 } from './schema';
 import { deprecate } from '@ember/debug';
-import { graphql } from 'graphql';
+import { GraphQLSchema, graphql } from 'graphql';
 
 export const composeCreateGraphQLHandler =
   (parseRequest, createSchema, addMocksToSchema, addInterfaceTypeResolversToSchema, graphql) =>
-    (rawSchema, options) =>
+    (schema, options) =>
       ({ db }, request) => {
         let { query, variables } = parseRequest(request.requestBody);
-        let schema = createSchema(rawSchema);
+
+        if (!(schema instanceof GraphQLSchema)) {
+          schema = createSchema(schema);
+        }
 
         if (options && options.varsMap) {
           deprecate('ember-cli-mirage-graphql varsMap is deprecated, please use argsMap instead', false, {

--- a/tests/unit/handler-test.js
+++ b/tests/unit/handler-test.js
@@ -1,6 +1,5 @@
 import { composeCreateGraphQLHandler } from 'ember-cli-mirage-graphql/handler';
-import gql from 'graphql-tag';
-import { mergeSchemas } from 'graphql-tools';
+import { makeExecutableSchema, mergeSchemas } from 'graphql-tools';
 import { module, test } from 'qunit';
 
 module('Unit | handler', function() {
@@ -60,24 +59,28 @@ module('Unit | handler', function() {
     test('it parses the request, creates mocks and resolvers for schema and returns GraphQL', function(assert) {
       assert.expect(7);
       
-      const fooSchema = gql`
-        type Foo {
-          name: String
-        }
+      const fooSchema = makeExecutableSchema({
+        typeDefs: `
+          type Foo {
+            name: String
+          }
 
-        type Query {
-          foos: [Foo]
-        }
-      `;
-      const barSchema = gql`
-        type Bar {
-          name: String
-        }
+          type Query {
+            foos: [Foo]
+          }
+        `
+      });
+      const barSchema = makeExecutableSchema({
+        typeDefs: `
+          type Bar {
+            name: String
+          }
 
-        type Query {
-          bars: [Bar]
-        }
-      `;
+          type Query {
+            bars: [Bar]
+          }
+        `
+      });
       const createSchema = () => assert.equal(0, 1); // This should not be called
       const schema = mergeSchemas({ schemas: [fooSchema, barSchema] });
       const createHandler = composeCreateHandler(createSchema, schema, assert);

--- a/tests/unit/handler-test.js
+++ b/tests/unit/handler-test.js
@@ -1,41 +1,89 @@
 import { composeCreateGraphQLHandler } from 'ember-cli-mirage-graphql/handler';
+import gql from 'graphql-tag';
+import { mergeSchemas } from 'graphql-tools';
 import { module, test } from 'qunit';
 
 module('Unit | handler', function() {
-  test('it parses the request, creates mocks and resolvers for schema and returns graphQL', function(assert) {
-    assert.expect(8);
+  const db = {};
+  const options = {};
+  const query = {};
+  const variables = {};
 
-    let db = {};
-    let options = {};
-    let query = {};
-    let rawSchema = {};
-    let schema = {};
-    let variables = {};
-    let addResolvers = (_schema) =>
-      assert.equal(_schema, schema, 'It received the schema');
-    let parseRequest = () => ({ query, variables });
+  const composeAddResolvers = (schema, assert) => (_schema) =>
+    assert.equal(_schema, schema, 'It received the schema');
+  
+  const parseRequest = () => ({ query, variables });
 
-    function addMocks(_schema, _db, _options) {
-      assert.equal(_schema, schema, 'It received the schema');
-      assert.equal(_db, db, 'It received the db');
-      assert.equal(_options, options, 'It received the options');
-    }
+  const composeAddMocks = (schema, assert) => (_schema, _db, _options) => {
+    assert.equal(_schema, schema, 'It received the schema');
+    assert.equal(_db, db, 'It received the db');
+    assert.equal(_options, options, 'It received the options');
+  };
 
-    function createSchema(_rawSchema) {
-      assert.equal(_rawSchema, rawSchema, 'It received the raw schema');
-      return schema;
-    }
+  const composeGraphQL = (schema, assert) => (_schema, _query, _, __, vars) => {
+    assert.equal(_schema, schema, 'It received the schema');
+    assert.equal(_query, query, 'It received the query');
+    assert.equal(vars, variables, 'It received the vars');
+  }
+  
+  const composeAdditionalCallbacks = (schema, assert) => [
+    composeAddMocks(schema, assert),
+    composeAddResolvers(schema, assert),
+    composeGraphQL(schema, assert)
+  ];
 
-    function graphQL(_schema, _query, _, __, vars) {
-      assert.equal(_schema, schema, 'It received the schema');
-      assert.equal(_query, query, 'It received the query');
-      assert.equal(vars, variables, 'It received the vars');
-    }
+  const composeCreateHandler = (createSchema, schema, assert) =>
+    composeCreateGraphQLHandler(
+      parseRequest,
+      createSchema,
+      ...composeAdditionalCallbacks(schema, assert));
 
-    let createHandler = composeCreateGraphQLHandler(parseRequest, createSchema,
-      addMocks, addResolvers, graphQL);
-    let handler = createHandler(rawSchema, options);
+  module('raw schema', function() {
+    test('it parses the request, creates mocks and resolvers for schema and returns GraphQL', function(assert) {
+      assert.expect(8);
 
-    handler({ db }, { request: {} });
+      const schema = {};
+
+      function createSchema(_schema) {
+        assert.equal(_schema, schema, 'It received the raw schema');
+        return schema;
+      }
+
+      const createHandler = composeCreateHandler(createSchema, schema, assert);
+      const handler = createHandler(schema, options);
+
+      handler({ db }, { request: {} });
+    });
   });
+
+  module('merged schema', function() {
+    test('it parses the request, creates mocks and resolvers for schema and returns GraphQL', function(assert) {
+      assert.expect(7);
+      
+      const fooSchema = gql`
+        type Foo {
+          name: String
+        }
+
+        type Query {
+          foos: [Foo]
+        }
+      `;
+      const barSchema = gql`
+        type Bar {
+          name: String
+        }
+
+        type Query {
+          bars: [Bar]
+        }
+      `;
+      const createSchema = () => assert.equal(0, 1); // This should not be called
+      const schema = mergeSchemas({ schemas: [fooSchema, barSchema] });
+      const createHandler = composeCreateHandler(createSchema, schema, assert);
+      const handler = createHandler(schema, options);
+      
+      handler({ db }, { request: {} });
+    });
+  })
 });


### PR DESCRIPTION
This PR allows for instances of `GraphQLSchema` to be passed into handlers instead of only allowing raw schemas. This should allow for cases like merging schemas and should fix #48.