### PR TITLE
Add deprecation info

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,5 +1,10 @@
 # Deprecations
 
+## Ember CLI Mirage GraphQL
+
+This Ember addon is deprecated in favor of
+[@miragejs/graphql](https://github.com/miragejs/graphql).
+
 ## varsMap (since 0.1.0)
 
 This option has been renamed to `argsMap` and now explicitly provides support

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Mock GraphQL with Ember CLI Mirage
+# Deprecated: Mock GraphQL with Ember CLI Mirage
 
-[![npm version](https://badge.fury.io/js/ember-cli-mirage-graphql.svg)](https://badge.fury.io/js/ember-cli-mirage-graphql)
-[![Build Status](https://travis-ci.org/kloeckner-i/ember-cli-mirage-graphql.svg?branch=master)](https://travis-ci.org/kloeckner-i/ember-cli-mirage-graphql)
-[![Coverage Status](https://coveralls.io/repos/github/kloeckner-i/ember-cli-mirage-graphql/badge.svg?branch=master)](https://coveralls.io/github/kloeckner-i/ember-cli-mirage-graphql?branch=master)
+This addon is deprecated in favor of [@miragejs/graphql](https://github.com/miragejs/graphql).
 
 This addon is for mocking GraphQL with Ember CLI Mirage.
 


### PR DESCRIPTION
This PR adds a little info to some markdown files to let developers know this addon has been deprecated. Closes #68.